### PR TITLE
Add Gemfile.lock to .gitignore

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,3 +3,4 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
+Gemfile.lock


### PR DESCRIPTION
Ignore Jekyll's `docs/Gemfile.lock`.