### PR TITLE
Update examples to use srun instead of salloc for interactive jobs

### DIFF
--- a/docs/getting-started/import-export-data.md
+++ b/docs/getting-started/import-export-data.md
@@ -167,8 +167,7 @@ Allocated port 45627 for remote forward to 127.0.0.1:22
 While the tunnel is open, you can connect to your local computer and access files from a worker node. For example, request an interactive job:
 
 ```
-[clusteruser@login01 ~]$ salloc --partition=free --nodes=1 --ntasks-per-node=1 --time=00:30:00 --mem=128mb --qos=interactive
-salloc: Nodes node15 are ready for job
+[clusteruser@login01 ~]$ srun --partition=free --nodes=1 --ntasks-per-node=1 --time=00:30:00 --mem=128mb --pty bash
 [clusteruser@node15 ~]$
 ```
 

--- a/docs/getting-started/slurm-basics.md
+++ b/docs/getting-started/slurm-basics.md
@@ -9,9 +9,9 @@ This page provides reference information for Slurm and strategies for how to use
 
 ## Accounts
 
-Any cluster user may submit jobs to the free partition without specifying an account using `srun --partition=free` or `salloc --partition=free`. Jobs on the free partition are limited in terms of their priority, hardware, and run time (max 3 hours). Jobs submitted to a higher tier of service must be associated with an account using `--account=<my account>`.
+Any cluster user may submit jobs to the free partition without specifying an account using `srun --partition=free`. Jobs on the free partition are limited in terms of their priority, hardware, and run time (max 3 hours). Jobs submitted to a higher tier of service must be associated with an account using `--account=<my account>`.
 
-Accounts are linked to a principal investigator (PI). By default, the account is named `<first_name>_<last_name>` in lowercase after the PI. For example, to submit a job to the tier1_cpu partition for the PI John Smith: `salloc --account-john_smith --partition=tier1_cpu`. If a job is not associated with an account then the job _must_ specify `--partition=free`.
+Accounts are linked to a principal investigator (PI). By default, the account is named `<first_name>_<last_name>` in lowercase after the PI. For example, to submit a job to the tier1_cpu partition for the PI John Smith: `srun --account-john_smith --partition=tier1_cpu`. If a job is not associated with an account then the job _must_ specify `--partition=free`.
 
 A research assistant, student, or post-doc may submit jobs under their PI's account. A lab member with more than one PI can specify which PI's account to use for which job by passing the appropriate `--account=` argument for that job.  PI's may set up an account, select a tier of service, and add/remove lab members who can submit jobs to that account by e-mailing [chpc@nrg.wustl.edu](mailto:chpc@nrg.wustl.edu).
 

--- a/docs/software/jupyter-notebook.md
+++ b/docs/software/jupyter-notebook.md
@@ -12,13 +12,12 @@ You can run a Jupyter Lab server as a cluster job and connect to it using a web 
 
 ## Setting Up a Compute Node
 
-Log into the cluster and use [`salloc`](https://slurm.schedmd.com/salloc.html) to request an interactive job with reasonable resources. Here we ask for 4 GB of memory, which should be enough for basic Python work, and 3 hours of runtime, which is the maximum allowed under the free tier. Take note of which node the job runs on.
+Log into the cluster and use [`srun`](https://slurm.schedmd.com/srun.html) to request an interactive job with reasonable resources. Here we ask for 4 GB of memory, which should be enough for basic Python work, and 3 hours of runtime, which is the maximum allowed under the free tier. We ask for an interactive bash terminal with `--pty bash`. Take note of which node the job runs on.
 
 ```
 [localuser@localmachine ~]$ ssh login3.chpc.wustl.edu
 Last login: Tue Sep 19 14:15:38 2023 from 10.20.145.192
-[clusteruser@login02 ~]$ salloc --partition=free --nodes=1 --time=3:00:00 --mem=4GB --qos=interactive
-salloc: Nodes node31 are ready for job
+[clusteruser@login02 ~]$ srun --partition=free --nodes=1 --time=3:00:00 --mem=4GB --pty bash
 [clusteruser@node31 ~]$ 
 ```
 
@@ -126,7 +125,7 @@ Then press `Ctrl + A` followed by `d` to "detach" from the terminal. You can use
 
 ## Running Jupyter as a Batch Job
 
-Instead of starting an interactive job with `salloc --qos=interactive` you may submit a batch job that automatically starts Jupyter. Create a slurm script like this one and give it a name like `jupyter.sh`. Make the script executable with `chmod u+x jupyter.sh`.
+Instead of starting an interactive job with `srun --pty bash` you may submit a batch job that automatically starts Jupyter. Create a slurm script like this one and give it a name like `jupyter.sh`. Make the script executable with `chmod u+x jupyter.sh`.
 
 ```bash
 #!/bin/bash

--- a/docs/software/matlabinteractive.md
+++ b/docs/software/matlabinteractive.md
@@ -13,13 +13,12 @@ exclude: true
 
 ## Terminal Interface
 
-Log into the cluster and start an interactive job on a compute node using [`salloc`](https://slurm.schedmd.com/salloc.html). Here we ask for 4 GB of memory, which should be enough for basic Matlab work, and 3 hours of runtime, which is the maximum allowed under the free tier.
+Log into the cluster and start an interactive job on a compute node using [`srun`](https://slurm.schedmd.com/srun.html). Here we ask for 4 GB of memory, which should be enough for basic Matlab work, and 3 hours of runtime, which is the maximum allowed under the free tier. We ask for an interactive bash terminal with `--pty bash`.
 
 ```
 [localuser@localmachine ~]$ ssh login3.chpc.wustl.edu
 Last login: Tue Sep 19 14:15:38 2023 from 10.20.145.192
-[clusteruser@login02 ~]$ salloc --partition=free --nodes=1 --time=3:00:00 --mem=4GB --qos=interactive
-salloc: Nodes node16 are ready for job
+[clusteruser@login02 ~]$ srun --partition=free --nodes=1 --time=3:00:00 --mem=4GB --pty bash
 [clusteruser@node16 ~]$ 
 ```
 

--- a/docs/software/visual-studio-code.md
+++ b/docs/software/visual-studio-code.md
@@ -10,15 +10,14 @@ exclude: true
 
 ## Setting Up a Compute Node
 
-Log into the cluster and use [`salloc`](https://slurm.schedmd.com/salloc.html) to request an interactive job with reasonable resources. Here we ask for 4 GB of memory, which should be enough for most development tasks, and 3 hours of runtime, which is the maximum allowed under the free tier. Take note of which node the job runs on.
+Log into the cluster and use [`srun`](https://slurm.schedmd.com/srun.html) to request an interactive job with reasonable resources. Here we ask for 4 GB of memory, which should be enough for most development tasks, and 3 hours of runtime, which is the maximum allowed under the free tier. We ask for an interactive bash terminal with `--pty bash`. Take note of which node the job runs on.
 
-> Note: VS Code's remote development extension works over SSH. At the time of this writing, the only compute node you can SSH into is node17. Request node17 specifically using `salloc -w node17`
+> Note: VS Code's remote development extension works over SSH. At the time of this writing, the only compute node you can SSH into is node17. Request node17 specifically using `srun -w node17`
 
 ```
 [localuser@localmachine ~]$ ssh login3.chpc.wustl.edu
 Last login: Tue Sep 19 14:15:38 2023 from 10.20.145.192
-[clusteruser@login02 ~]$ salloc -w node17 --partition=free --nodes=1 --time=3:00:00 --mem=4GB --qos=interactive
-salloc: Nodes node17 are ready for job
+[clusteruser@login02 ~]$ srun -w node17 --partition=free --nodes=1 --time=3:00:00 --mem=4GB --pty bash
 [clusteruser@node17 ~]$ 
 ```
 


### PR DESCRIPTION
Several current examples use `salloc --qos=interactive` to start interactive jobs. This no longer works after the recent cluster upgrade because the interactive qos no longer exists. Updated examples to use `srun --pty bash` instead.