### PR TITLE
Use hostname instead of IP address for reverse tunnel

### DIFF
--- a/docs/getting-started/import-export-data.md
+++ b/docs/getting-started/import-export-data.md
@@ -114,7 +114,7 @@ sftp> quit
 
 ### sshfs
 
-You may use `sshfs` to mount your local computer's filesystem over the reverse tunnel using the same principles as above. Note that the mount will only be visible on the login node -- it will not be visible on a worker node running a job.
+You may use `sshfs` to mount your local computer's filesystem over the reverse tunnel using the same principles as above. Note that the mount will only be visible on the login node -- it will not be visible on a compute node running a job.
 
 ```
 [clusteruser@login01 ~]$ mkdir ~/local_mnt
@@ -138,40 +138,35 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>> # ...
 ```
 
-## Controlling Transfers Using a Worker Node
+## Controlling Transfers Using a Compute Node
 
-The login node is not suitable for computational tasks. Sometimes you will want to access a remote filesystem directly from a worker node running a computational job. For example, you might start an interactive, remote desktop environment on a worker node and want to copy files to and from your local desktop computer. You can connect from a worker node to your local network using a reverse tunnel. The process is similar to that for creating a reverse tunnel to a login node (see above).
+The login node is not suitable for computational tasks. Sometimes you will want to access a remote filesystem directly from a compute node running a computational job. For example, you might start an interactive, remote desktop environment on a compute node and want to copy files to and from your local desktop computer. You can connect from a compute node to your local network using a reverse tunnel. The process is similar to that for creating a reverse tunnel to a login node (see above).
 
-At the time of this writing, reverse tunnels to a worker node are only supported on login01. You can connect to login01 explicitly using it's IP address. It is, numerically, the first IP address.
+> Note: At the time of this writing, reverse tunnels to a compute node are only supported on login01, so you will need to connect to it explicitly.
 
-```
-[localuser@localmachine ~]$ host login3.chpc.wustl.edu
-login3.chpc.wustl.edu has address 128.252.185.8 # login02
-login3.chpc.wustl.edu has address 128.252.185.7 # login01
-```
-
-Then use the following syntax to open the reverse tunnel.
+Use the following syntax to open the reverse tunnel:
 - `-R` requests a reverse tunnel.
-- `login01` resolves to 10.1.1.251 and specifies which IP address the tunnel should listen on. Without this, the tunnel defaults to listening on 127.0.0.1 and would only be accessible from the login node. Binding to an external IP address allows worker nodes on the cluster's subnet to connect to the tunnel.
+- `login01` resolves to 10.1.1.251, the cluster-facing IP address for login01. Without this, the tunnel defaults to listening on 127.0.0.1 and would only be accessible from login01 itself. Binding to an external IP address allows compute nodes on the cluster's subnet to connect to the tunnel.
 - `0` makes ssh automatically allocate an open port for the tunnel to listen on, in this case 45627.
 - `127.0.0.1` refers to your local computer. You may specify a different tunnel endpoint on your local computer's subnet.
 - `22` is the port at the tunnel's endpoint to send data to. You may specify a different port if you want to tunnel a protocol other than ssh.
+- `login3-01.chpc.wustl.edu` resolves to 128.252.185.7, the outward-facing IP address for login01.
 
 ```
-[localuser@localmachine ~]$ ssh -R login01:0:127.0.0.1:22 clusteruser@128.252.185.7
+[localuser@localmachine ~]$ ssh -R login01:0:127.0.0.1:22 clusteruser@login3-01.chpc.wustl.edu
 Allocated port 45627 for remote forward to 127.0.0.1:22
 [clusteruser@login01 ~]$ # do your file transfers here
 [clusteruser@login01 ~]$ exit # close the tunnel
 ```
 
-While the tunnel is open, you can connect to your local computer and access files from a worker node. For example, request an interactive job:
+While the tunnel is open, you can connect to your local computer and access files from a compute node. For example, request an interactive job:
 
 ```
 [clusteruser@login01 ~]$ srun --partition=free --nodes=1 --ntasks-per-node=1 --time=00:30:00 --mem=128mb --pty bash
 [clusteruser@node15 ~]$
 ```
 
-And then user sftp, sshfs, etc. from the worker node. (Use the automatically allocated port in place of 2222).
+And then user sftp, sshfs, etc. from the compute node. (Use the automatically allocated port in place of 2222).
 
 ```
 [clusteruser@node15 ~]$ sftp -P 2222 localuser@login01


### PR DESCRIPTION
Improve the workflow for reverse tunnels by connecting to login01 using its hostname rather than its IP address.  Also change "worker node" to "compute node" for consistency with the rest of the documentation.