### PR TITLE
Update Jupyter description with YouTube content

### DIFF
--- a/docs/getting-started/connect-to-login-nodes.md
+++ b/docs/getting-started/connect-to-login-nodes.md
@@ -74,11 +74,13 @@ For example: `sudo openconnect --protocol=anyconnect --useragent="AnyConnect-com
 
 ### Entering my password to login every time is so annoying ... How can I connect to the cluster without entering the password?
 
-Luckily, a more secure and convenient way to log into the cluster is using a SSH key-pair! SSH key-pairs can be more secure, as they are less vulnerable to common brute-force password attacks ... and more convenient. So yes, you can have your access cake and eat it too ... almost: If the user’s workstation were compromised, the malicious user could then connect to the CHPC without needing a password. All things considered, it is much more difficult to access a physical machine than sitting somewhere else picking away at passwords, so we suggest this method.
+Luckily, a more secure _and_ convenient way to log into the cluster is using a SSH key-pair! SSH key-pairs can be more secure, as they are less vulnerable to common brute-force password attacks ... and more convenient. An SSH key-pair consist of a public key and a private key. You can place the public key on any server, and then connect to the server using an SSH client with access to the private key. When the public and private keys match up, the SSH server grants access without the need for a password.
 
-An SSH key-pair consist of a public key and a private key. You can place the public key on any server, and then connect to the server using an SSH client with access to the private key. When the public and private keys match up, the SSH server grants access without the need for a password.
+So yes, you can have your access cake and eat it too ...
 
-But enough explanation, let's get to making one of these and getting you connected. You can follow [these instructions from our friends at Github](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to generate your key and add it to your ssh-agent. Basically:
+**Step 1: Create the key pair**
+
+You can follow [these instructions from our friends at Github](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to generate your key and add it to your `ssh-agent`. Basically:
 * For Linux OS or MacOS, you simply need to run “ssh-keygen” command in a terminal window. You can just hit enter to accept all of the defaults.
 * For Windows OS, you can run the command in mobaxterm. An example of generating a rsa-type key pair in mobaxterm is shown as below:
 
@@ -113,6 +115,21 @@ The key's randomart image is:
 +----[SHA256]-----+
 ```
 
+**Step 2 (optional): Add the key to your ssh-agent**
+
+We recommend you add a passphrase to your key ... but if you set up your SSH key to have a passphrase, doesn't that take away the convenience? It can, but there is a convenient solution to that, too:  SSH agent! 
+
+You can start a local terminal session and do the following just once every time you start working:
+```
+[me@local_machine]: eval "$(ssh-agent -s)"
+[me@local_machine]: ssh-add ~/.ssh/id_ed25519
+Enter passphrase for /Users/me/.ssh/id_ed25519:
+```
+
+Now the SSH agent will manage key requests and not bother you with the key passphrase ... at least until you need to login to your local machine again.
+
+**Step 3: Send the key to the cluster**
+
 The next step would be to place the public key on the login nodes.
 
 ```
@@ -127,9 +144,10 @@ Now try logging into the machine, with:   "ssh 'me@login3-01.chpc.wustl.edu'"
 and check to make sure that only the key(s) you wanted were added.
 ```
 
-Alternatively, the user could manually edit the ~/.ssh/authorized\_keys and add a copy of their public key.
+Alternatively, the user could manually edit the `~/.ssh/authorized_keys` and add a copy of their public key as an entry in the file.
 
-Be aware, SSH is very sensitive to file permissions. If the permissions would allow another user to edit files under ~/.ssh, SSH will silently fail using key-pairs and revert back to password authentication. For this reason, do the following:
+> [!danger] SSH is sensitive to file permissions! If the permissions allow another user to view files under `~/.ssh`, SSH will silently fail and revert back to password authentication. For this reason, do the following
+
 ```
 chmod -R 600 ~/.ssh
 ```

--- a/docs/software/jupyter-notebook.md
+++ b/docs/software/jupyter-notebook.md
@@ -8,7 +8,45 @@ author: Benjamin Kay
 [Jupyter](https://jupyter.org/) and the Jupyter Lab notebook interface are a widely-used open-source project for interactive, reproducible computing. They are widely used by data scientists. For example, Jupyter powers [Google Colab](https://colab.research.google.com/) and the automatic manuscript figure rendering in [Quarto](https://quarto.org/). Jupyter is written in Python but supports many data science languages including R, Julia, and Matlab.
 
 You can run a Jupyter Lab server as a cluster job and connect to it using a web browser on your local computer. This setup is very convenient for interacting with large data sets and computational expensive operations that would grind your laptop to a halt. It's also a great way to incrementally develop batch jobs to run on the cluster.
+## Quick Start
 
+Read below for other ways, but here we go over the method in our [YouTube video](https://youtu.be/ad0YMKDNNZ8) for how to access Jupyter Notebooks in your local web browser using storage and GPUs on the CHPC! The text instructions follow (if you are already a user you can probably skip to 3 or 4):
+
+**Prereqs:**
+1. [Get an account](<../getting-started/applying-for-a-user-account>)
+2. [Connect to the VPN and set up SSH keys](../getting-started/connect-to-login-nodes)
+3. [Setup Miniconda](python)
+
+First, create and activate a new conda environment with the packages you need for your research (at a minimum it will need `jupyterlab`).
+
+For instance:
+```
+[clusteruser@login01 ~]$ . ~/miniconda3/bin/activate
+[clusteruser@login01 ~]$ conda env create -n jlab -c conda-forge jupyterlab
+```
+
+Second, get a Slurm allocation to give you resources to run your Jupyter Lab notebooks:
+```
+[clusteruser@login01 ~]$ salloc -N1 -n1 --gpus=1 --partition=tier2_gpu --account=admin --time=40:00
+salloc: Pending job allocation XXXXX
+salloc: job XXXXX queued and waiting for resources
+```
+
+Third, once you have resources allocated you can run Jupyter Lab:
+```
+[clusteruser@gpu01 ~]$ . ~/miniconda3/bin/activate
+[clusteruser@gpu01 ~]$ conda activate jlab
+(jlab)[clusteruser@gpu01 ~]$ jupyter lab --ServerApp.allow_remote_access=True --ServerApp.ip=* --ServerApp.open_browser=False
+```
+
+Once the server is running, open a new terminal from your local machine and open an SSH tunnel through the CHPC login node to the GPU node you were allocated:
+```
+[localuser@localmachine ~]$ ssh -L 9876:gpu01:8888 me@login3.chpc.wustl.edu
+```
+
+Now, you can open your browser and navigate to `http://127.0.0.1:9876`. In the text box prompt, just enter the token given with the URL displayed when you ran Jupyter Lab.
+
+Done! You can now create Jupyter Notebooks and save them in your CHPC home directory. You can also use the GPUs and CPUs on the CHPC to run your analyses.
 ## Setting Up a Compute Node
 
 Log into the cluster and use [`srun`](https://slurm.schedmd.com/srun.html) to request an interactive job with reasonable resources. Here we ask for 4 GB of memory, which should be enough for basic Python work, and 3 hours of runtime, which is the maximum allowed under the free tier. We ask for an interactive bash terminal with `--pty bash`. Take note of which node the job runs on.

--- a/docs/software/jupyter-notebook.md
+++ b/docs/software/jupyter-notebook.md
@@ -13,9 +13,9 @@ You can run a Jupyter Lab server as a cluster job and connect to it using a web 
 Read below for other ways, but here we go over the method in our [YouTube video](https://youtu.be/ad0YMKDNNZ8) for how to access Jupyter Notebooks in your local web browser using storage and GPUs on the CHPC! The text instructions follow (if you are already a user you can probably skip to 3 or 4):
 
 **Prereqs:**
-1. [Get an account](<../getting-started/applying-for-a-user-account>)
-2. [Connect to the VPN and set up SSH keys](../getting-started/connect-to-login-nodes)
-3. [Setup Miniconda](python)
+1. [Get an account](../getting-started/applying-for-a-user-account.md)
+2. [Connect to the VPN and set up SSH keys](../getting-started/connect-to-login-nodes.md)
+3. [Setup Miniconda](python.md)
 
 First, create and activate a new conda environment with the packages you need for your research (at a minimum it will need `jupyterlab`).
 

--- a/docs/software/jupyter-notebook.md
+++ b/docs/software/jupyter-notebook.md
@@ -17,34 +17,33 @@ Read below for other ways, but here we go over the method in our [YouTube video]
 2. [Connect to the VPN and set up SSH keys](../getting-started/connect-to-login-nodes.md)
 3. [Setup Miniconda](python.md)
 
-First, create and activate a new conda environment with the packages you need for your research (at a minimum it will need `jupyterlab`).
-
-For instance:
+4. Create and activate a new conda environment with the packages you need for your research (at a minimum it will need `jupyterlab`). For instance:
 ```
 [clusteruser@login01 ~]$ . ~/miniconda3/bin/activate
 [clusteruser@login01 ~]$ conda create --name jlab --channel=conda-forge jupyterlab
 ```
 
-Second, get a Slurm allocation to give you resources to run your Jupyter Lab notebooks:
+5. Get a Slurm allocation to give you resources to run your Jupyter Lab notebooks:
 ```
 [clusteruser@login01 ~]$ salloc -N1 -n1 --gpus=1 --partition=tier1_gpu --account=pi_name --time=40:00
 salloc: Pending job allocation XXXXX
 salloc: job XXXXX queued and waiting for resources
 ```
 
-Third, once you have resources allocated you can run Jupyter Lab:
+6. Once you have resources allocated you can run Jupyter Lab:
 ```
 [clusteruser@gpu01 ~]$ . ~/miniconda3/bin/activate
 [clusteruser@gpu01 ~]$ conda activate jlab
 (jlab)[clusteruser@gpu01 ~]$ jupyter lab --ServerApp.allow_remote_access=True --ServerApp.ip=* --ServerApp.open_browser=False
 ```
 
-Once the server is running, open a new terminal from your local machine and open an SSH tunnel through the CHPC login node to the GPU node you were allocated:
+7. Once the server is running, open a new terminal from your local machine and open an SSH tunnel through the CHPC login node to the GPU node you were allocated:
 ```
-[localuser@localmachine ~]$ ssh -L 9876:gpu01:8888 me@login3.chpc.wustl.edu
+[localuser@localmachine ~]$ ssh -L 8888:gpu01:8888 me@login3.chpc.wustl.edu
 ```
-
-Now, you can open your browser and navigate to `http://127.0.0.1:9876`. In the text box prompt, just enter the token given with the URL displayed when you ran Jupyter Lab.
+> Note: If 8888 is being used on your local machine, just replace the first "8888" with another open port like "9876" (e.g., `ssh -L 9876:gpu01:8888 me@login3.chpc.wustl.edu`) and then also use that new port after the ":" in the next step, too.
+8. You can now open your browser on your local machine and navigate to `http://127.0.0.1:8888` (or look at the output from 6. to get the URL with the token and skip 9.)
+9. In the text box prompt, just enter the token given as part of the URL displayed when you ran Jupyter Lab in 6.
 
 Done! You can now create Jupyter Notebooks and save them in your CHPC home directory. You can also use the GPUs and CPUs on the CHPC to run your analyses.
 ## Setting Up a Compute Node

--- a/docs/software/jupyter-notebook.md
+++ b/docs/software/jupyter-notebook.md
@@ -22,12 +22,12 @@ First, create and activate a new conda environment with the packages you need fo
 For instance:
 ```
 [clusteruser@login01 ~]$ . ~/miniconda3/bin/activate
-[clusteruser@login01 ~]$ conda env create -n jlab -c conda-forge jupyterlab
+[clusteruser@login01 ~]$ conda create --name jlab --channel=conda-forge jupyterlab
 ```
 
 Second, get a Slurm allocation to give you resources to run your Jupyter Lab notebooks:
 ```
-[clusteruser@login01 ~]$ salloc -N1 -n1 --gpus=1 --partition=tier2_gpu --account=admin --time=40:00
+[clusteruser@login01 ~]$ salloc -N1 -n1 --gpus=1 --partition=tier1_gpu --account=pi_name --time=40:00
 salloc: Pending job allocation XXXXX
 salloc: job XXXXX queued and waiting for resources
 ```


### PR DESCRIPTION
I recently added a YouTube video to go over the process for starting and managing a Jupyter Lab instance on the CHPC. This updates the docs to include a textual description of that procedure along with a reference to the video.