### PR TITLE
Document how to access SMB shares

### DIFF
--- a/docs/getting-started/import-export-data.md
+++ b/docs/getting-started/import-export-data.md
@@ -36,7 +36,6 @@ Linux users and Mac users (via Homebrew) can access the cluster filesystem with 
 [localuser@localmachine ~]$ cp ~/cluster_mnt/clusterfile ./ # fetch from cluster
 [localuser@localmachine ~]$ fusermount -u ~/cluster_mnt    # unmount
 ```
-
 ### sftp + Python
 
 [Python](https://www.python.org/) is a programming language that is widely-used for scientific computing. You can transfer files over sftp directly from your Python scripts using [Paramiko](https://www.paramiko.org/). This functionality is particularly powerful when combined with Python's interactive [Jupyter notebooks](https://jupyter.org/). See the full API documentation [here](https://docs.paramiko.org/en/3.3/api/sftp.html).
@@ -120,6 +119,27 @@ You may use `sshfs` to mount your local computer's filesystem over the reverse t
 [clusteruser@login01 ~]$ cp clusterfile ~/local_mnt  # upload to local machine
 [clusteruser@login01 ~]$ cp ~/local_mnt/localfile ./ # fetch from local machine
 [clusteruser@login01 ~]$ fusermount -u ~/local_mnt   # unmount
+```
+
+### SMB
+
+The server message block ([SMB](https://en.wikipedia.org/wiki/Server_Message_Block)) protocol was invented in 1983 and is still used by some [Microsoft Windows](https://learn.microsoft.com/en-us/windows-server/storage/file-server/file-server-smb-overview) systems and by the [RIS cluster](https://ris.wustl.edu/services/research-storage/). You can access SMB shares with the [`smbclient`](https://www.samba.org/samba/docs/current/man-html/smbclient.1.html) program using a syntax similar to `sftp`. If your share happens to be on the RIS cluster then no tunneling is necessary.
+
+```
+[user@login01 ~]$ smbclient -W ACCOUNTS -U user -m SMB3 \\storage1.ris.wustl.edu/my_storage/
+```
+
+You can also mount an SMB share in a manner similar to `sshfs`. Note that you will need to first [manually start a dbus daemon](../software/dbus.md) to mount an SMB share on a compute node.
+
+```
+[user@login01 ~]$ gio mount smb://storage1.ris.wustl.edu/my_storage
+[user@login01 ~]$ ls $XDG_RUNTIME_DIR/gvfs
+```
+
+The mount will appear under `$XDG_RUNTIME_DIR/gvfs`. To unmount use `gio mount -u`:
+
+```
+[user@login01 ~]$ gio mount -u smb://storage1.ris.wustl.edu/my_storage
 ```
 
 ### sftp + Python

--- a/docs/software/dbus.md
+++ b/docs/software/dbus.md
@@ -1,0 +1,30 @@
+---
+title: DBUS
+created: 2024-06-05T21:44:00 (UTC -04:00)
+tags: []
+source: https://www.freedesktop.org/wiki/Software/dbus/
+author: Benjamin Kay
+---
+
+[D-Bus](https://www.freedesktop.org/wiki/Software/dbus/) is a system messaging bus for inter-process communication. You probably are not interested in using dbus on its own, but you may need to use software that depends on dbus.
+
+D-Bus is installed on all of the RCIF nodes. A dbus daemon is started automatically when you ssh into a login node. You will need to start a dbus daemon manually on compute nodes. This guide explains how to work around some idiosyncracies of the slurm environment to get a working dbus daemon started on a compute node.
+
+There are two obstacles to starting dbus on a compute node:
+
+1. The default user runtime directory under `/run/user` does not exist.
+2. The dbus daemon does not have permission to create unix sockets in `/tmp`.
+
+To work around these issues, create a runtime directory somewhere in your home directory and place the dbus daemon's unix socket there. In this example we will call the runtime directory `xdg` and the socket `bus`. You may need a mechanism to ensure unique names (e.g. using `mktemp`) to avoid collisions between dbus sessions between parallel jobs.
+
+```
+[user@node01 ~]$ mkdir $HOME/xdg
+[user@node01 ~]$ export XDG_RUNTIME_DIR=$HOME/xdg
+[user@node01 ~]$ dbus-daemon --session --fork \
+--address unix:path=$XDG_RUNTIME_DIR/bus \
+--print-address 1 > dbus-addr.txt
+[user@node01 ~]$ export DBUS_SESSION_BUS_ADDRESS=$(cat dbus-addr.txt)
+```
+
+Now the dbus daemon should be running and programs that require dbus should Just Work:tm:. The dbus daemon should be stopped automatically when your job ends.
+

--- a/docs/software/software.md
+++ b/docs/software/software.md
@@ -15,6 +15,7 @@ We support a variety of software on the RCIF HPC cluster
 * [cmake](cmake.md)
 * [cuda](cuda.md)
 * [cudnn](cudnn.md)
+* [dbus](dbus.md)
 * [dcmtk](dcmtk.md)
 * [dramms](dramms.md)
 * [elastix](elastix.md)


### PR DESCRIPTION
The RIS cluster uses the SMB protocol. This PR adds information about accessing SMB shares to the import/export data section. Using gvfs to mount SMB shares on compute nodes requires dbus. This PR adds a page under Software explaining how to start dbus on a compute node.