### PR TITLE
updates: events, WUSTL key reset, Slack link

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -14,6 +14,7 @@ Welcome to another year at the Research Computing and Informatics Facility (RCIF
 	10am-1pm
 
 REGISTER [HERE](https://docs.google.com/forms/d/1gkAjVXBKgbfWu2ZZerlVAJHL-rZJGLo2tnGPS1__zQ4)!
+### Overview
 
 We will discuss the various services we offer, important updates since last year, and our vision over the next 12 months, including details about data migration to our new data storage cluster!
 
@@ -25,18 +26,27 @@ About the RCIF (see also [https://docs.chpc.wustl.edu/](https://docs.chpc.wustl.
 - **Data storage**: We provide nearly 20PB through our data facility and our Specialized Data Storage (SDS).
 - **CHPC**: We offer massively parallel computing resources through the Center for High Performance Computing (CHPC) with over 100 datacenter class GPUs and 1000’s of CPU cores, all with consistent access to data.
 - **Server hosting**: We host servers, allowing dedicated computing resources with the ability to “burst” computing to our CHPC computing resources when needed – all with access to data.
+### Agenda
+* 10-10:30        Breakfast (please [register](https://docs.google.com/forms/d/1gkAjVXBKgbfWu2ZZerlVAJHL-rZJGLo2tnGPS1__zQ4))
+* 10:30-11:30   Presentations
+* 11:30-12         Lunch
+* 12-1                Reserved for Q&A, workshops, and tutorials
+
+
 ## Other Upcoming Events
-* **Sept 4** - RCIF Applied AI Seminar - *10am in the NIL Conference Room (2FL East Imaging - Room 2311)*
-* Sept 18 - RCIF Applied AI Seminar - *10am in the NIL Conference Room (2FL East Imaging - Room 2311)*
+* **October 2** - RCIF Applied AI Seminar (9:30am - East Imaging 2311)
+* **October 16** -RCIF Applied AI Seminar (10am - East Imaging 2311)
 # Past Events
 Below are some of our past events with links to visuals and chats when available.
 ## 2024
-* **August 21** - RCIF Applied AI Seminar "Bayesian ML for Healthcare Applications" is also available - see [here](https://youtu.be/dG8H86WDmSo).
+* **Sept 18** - RCIF Applied AI Seminar "Model Evaluation with Tensorboard" - see [here](https://youtu.be/hPUKji5h9Qo).
+* **Sept 4** - RCIF Applied AI Seminar "Introduction to High-Performance Computing" - see [here](https://youtu.be/2y-YvHC47Ws).
+* **August 21** - RCIF Applied AI Seminar "Bayesian ML for Healthcare Applications" - see [here](https://youtu.be/dG8H86WDmSo).
 * **August 7** - RCIF Applied AI Seminar "Semi-Supervised Image Labeling with Vector Embeddings"- see [here](https://youtu.be/HhNE0qtLzg8).
 * **July 17** - RCIF Applied AI Seminar on Causal ML - see [here](https://youtu.be/k_e5QWZeAWE).
 * **July 3** - RCIF Applied AI Seminar on Explainable AI - see [here](https://youtu.be/tfjHCZUqSZo).
 * **June 6-7** - Maintenance window - CHPC access offline
-* **June 5** - RCIF Applied AI Seminar "Training Segmentation Models with MONAI and MedSAM" - see [here](https://youtu.be/y1weVHMYNG8) - *9am in the NIL Conference Room (2FL East Imaging - Room 2311)*
+* **June 5** - RCIF Applied AI Seminar "Training Segmentation Models with MONAI and MedSAM" - see [here](https://youtu.be/y1weVHMYNG8)
 * **May 28** - MIR Research Symposium (see [here](https://wustl.box.com/s/c73onlinbp3pl51hwbejbc2k9la6s98p) for a copy of our CHPC poster and [here](https://wustl.box.com/s/0obltgp2f4cl5svp2ue366kf2r4yp2gs) for our Informatics poster)
 * **May 17** - RCIF Users meeting (see [here]() for the meeting recording)
 * **May 15** - RCIF Applied AI Seminar "Best practices for running parallel processes on CPU/GPU" - see [here](https://youtu.be/22AuIowrMHE).

--- a/docs/getting-started/connect-to-login-nodes.md
+++ b/docs/getting-started/connect-to-login-nodes.md
@@ -8,7 +8,6 @@ source: https://sites.wustl.edu/chpc/for-users/frequently-asked-questions-faq/co
 author:
 include: true
 ---
-
 ### What is the hostname for the login nodes of the cluster?
 
 We have two (2) login nodes: `login01` and `login02`.
@@ -18,8 +17,8 @@ To connect to the login node, you simply connect to `login3.chpc.wustl.edu`
 If you ever have trouble connecting to `login3.chpc.wustl.edu`, you can directly connect to either:
 - `login01`: `login3-01.chpc.wustl.edu` (`128.252.185.7`)
 - `login02`: `login3-02.chpc.wustl.edu` (`128.252.185.8`)
-
 ### How do I connect to these login nodes?
+
 If you are on the WashU network, you can directly connect to the cluster (note: if _NOT_ on the WashU cluster you will need to [setup 2-factor authentication](#how-can-i-set-up-2-factor-authentication-on-my-personal-device) and [setup and start the WashU VPN](#how-can-i-access-the-cluster-from-off-campus))
 
 The cluster is Linux-based (see [training and support](training-and-support.md) if you are interested in programs to get familiarized with Linux). The easiest way is to SSH using your favorite terminal application ("mobaxterm" is one choice for Windows, and Terminal is built in to MacOS - another excellent cross-platform option is "Visual Studio Code", which not only has a multi-terminal window built in but also has a great set of tools for working with source code and containers).
@@ -47,7 +46,9 @@ total 0
 [me@login01 ~]$ ls -lh /home/me
 total 0
 ```
+### How do I reset my password?
 
+We use your WUSTL Key for authentication on the CHPC. If you need to reset your WUSTL Key, please visit WUIT at [https://it.wustl.edu/items/how-do-i-change-my-wustl-key-password/](https://it.wustl.edu/items/how-do-i-change-my-wustl-key-password).
 ### How can I set up 2-factor authentication on my personal device?
 
 The university requires users to enable 2-factor authentication (2FA) on their personal devices to connect to campus network. This is a prerequisite to connect to the login node while you are off campus.
@@ -55,7 +56,6 @@ The university requires users to enable 2-factor authentication (2FA) on their p
 Firstly, you need to install the **Duo** app on your personal device either through Google Play if you are using Android devices or through Apple Store if you are using Apple devices. After that, you can enroll in WashU 2-step authentication and create a 2FA account. Finally, you would link your 2FA account to Duo app on your personal device.
 
 The detailed instruction can be found [here](https://it.wustl.edu/items/2fa-enrollment/).
-
 ### How can I access the cluster from off campus?
 
 In order to connect to the login nodes from off campus, you need to establish the connection via virtual private network (VPN):
@@ -71,7 +71,6 @@ In order to connect to the login nodes from off campus, you need to establish th
 Users have reported that if you are connecting from a Linux computer after 11/20/23, you need to set your useragent string to something starting with AnyConnect to be directed to the new SSO process. If you use an old useragent string, the gateway will repeatedly ask you for your username and password rather than giving you an error.
 
 For example: `sudo openconnect --protocol=anyconnect --useragent="AnyConnect-compatible OpenConnect VPN Agent" https://msvpn.wusm.wustl.edu/`
-
 ### Entering my password to login every time is so annoying ... How can I connect to the cluster without entering the password?
 
 Luckily, a more secure _and_ convenient way to log into the cluster is using a SSH key-pair! SSH key-pairs can be more secure, as they are less vulnerable to common brute-force password attacks ... and more convenient. An SSH key-pair consist of a public key and a private key. You can place the public key on any server, and then connect to the server using an SSH client with access to the private key. When the public and private keys match up, the SSH server grants access without the need for a password.
@@ -154,15 +153,16 @@ chmod -R 600 ~/.ssh
 
 If you have any questions or problems, please [see our support options](../getting-started/training-and-support.md)!
 ### How do I get my data onto the CHPC?
+
 There is a great guide on transfer options [here](import-export-data.md).
 
 We can also provide access to several human imaging datasets, which we host for free as part of our shared datasets program, and if we do not have it you can request it. See our [datasets page](rcif-shared-datasets.md) for more information and howto's.
 
 Contact us via [our support options](training-and-support.md) if you have specific needs not addressed.
 ### What if I want to share data among users in my group?
+
 We have several groups that do this, and all you have to do is contact us via one of [our support options](training-and-support.md) to get this started.
 
 We will create and configure a directory in `/ceph/chpc/shared` and apply permissions as you want (e.g., we can allow all members of your group, an arbitrary list of users, or even use an Active Directory group to manage the access list).
 
 Fees will be assessed based on the amount of data stored. See our [accounting FAQs](faqs-accounting.md#how-is-storage-charged).
-

--- a/docs/getting-started/training-and-support.md
+++ b/docs/getting-started/training-and-support.md
@@ -16,7 +16,7 @@ You have several ways of contacting us for one-on-one or crowd-sourced support.
 * This documentation is a great resource for up-to-date information.
 * Join our Slack workspace "RCIF Applied HPC/AI Working Group"; here is an [invitation](https://join.slack.com/t/mir-rcif/shared_invite/zt-2pj3dtsg1-8TatbKK0He4Ts2~vYl6xrw). This is an engaged and helpful community; feel free to post your questions to the community, or you can ask us for help directly on the _#ask-an-admin_ channel.
 * Receive news and advisories on the [CHPC Users email group](https://gowustl.sharepoint.com/sites/chpc-users); all new users are added when they receive an account on the CHPC.
-* Schedule a one-on-one meeting with Dennis [here](https://calendly.com/rcif-hpc-admin-office-hours/hpc-ai-consult)
+* Schedule a one-on-one meeting with Dennis [here](https://calendly.com/rcif-hpc-admin-office-hours/in-person-chat).
 * On campus? You can find us on the 3rd floor of the East Imaging Building in the CIRC
 * Email support for the various services, including CHPC (__chpc _at_ nrg.wustl.edu__), CNDA (__cnda-help _at_ wustl.edu__), and MIRRIR (__mirrir-help _at_ wustl.edu__).
 * Check out our [YouTube channel](https://www.youtube.com/@rcifwustl) for additional content, including videos from user meetings and RCIF Open House events.

--- a/docs/getting-started/training-and-support.md
+++ b/docs/getting-started/training-and-support.md
@@ -14,10 +14,10 @@ We are currently putting together our topic schedule for 2024. Please check back
 You have several ways of contacting us for one-on-one or crowd-sourced support.
 
 * This documentation is a great resource for up-to-date information.
-* Join our Slack workspace "RCIF Applied HPC/AI Working Group"; here is an [invitation](https://join.slack.com/t/mir-rcif/shared_invite/zt-2mr9wtiza-m5k3dSOBA1cbshlGU9DKxw). This is an engaged and helpful community; feel free to post your questions to the community, or you can ask us for help directly on the _#ask-an-admin_ channel.
+* Join our Slack workspace "RCIF Applied HPC/AI Working Group"; here is an [invitation](https://join.slack.com/t/mir-rcif/shared_invite/zt-2pj3dtsg1-8TatbKK0He4Ts2~vYl6xrw). This is an engaged and helpful community; feel free to post your questions to the community, or you can ask us for help directly on the _#ask-an-admin_ channel.
 * Receive news and advisories on the [CHPC Users email group](https://gowustl.sharepoint.com/sites/chpc-users); all new users are added when they receive an account on the CHPC.
 * Schedule a one-on-one meeting with Dennis [here](https://calendly.com/rcif-hpc-admin-office-hours/hpc-ai-consult)
-* On campus? You can often find us on the 3rd floor of the East Imaging Building in the CIRC
+* On campus? You can find us on the 3rd floor of the East Imaging Building in the CIRC
 * Email support for the various services, including CHPC (__chpc _at_ nrg.wustl.edu__), CNDA (__cnda-help _at_ wustl.edu__), and MIRRIR (__mirrir-help _at_ wustl.edu__).
 * Check out our [YouTube channel](https://www.youtube.com/@rcifwustl) for additional content, including videos from user meetings and RCIF Open House events.
 * See our [Substack](https://rcifhpc.substack.com/) for news for the RCIF and CHPC.


### PR DESCRIPTION
Add to the events page:
* Open house agenda
* More links to YouTube videos from past talks
* Upcoming RCIF Applied AI seminars

Add a section on resetting your WUSTL Key

Update the Slack link to one without an expiration